### PR TITLE
Rework modal-background example to eliminate ignore-children

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ When you're using the block form of `from-elsewhere`, it's entirely up to you wh
 ```hbs
 {{#from-elsewhere name="modal" as |modal|}}
   {{#liquid-bind modal as |currentModal|}}
-    <div class="modal-background"></div>
-    <div class="modal-container" onclick={{action currentModal.onOutsideClick}}>
+    <div class="modal-container">
+      <div class="modal-background" onclick={{action currentModal.onOutsideClick}}></div>
       <div class="modal-dialog" >
         {{component currentModal.body}}
       </div>

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -72,4 +72,6 @@ nav a.active {
     padding: 4em;
     border-radius: 5px;
     border: 1px solid #B4B4E8;
+    position: relative;
+    z-index: 1;
 }

--- a/tests/dummy/app/templates/components/modal-target.hbs
+++ b/tests/dummy/app/templates/components/modal-target.hbs
@@ -1,8 +1,8 @@
 {{#from-elsewhere name="modal" as |modal|}}
   {{#liquid-bind modal containerless=true use=modalAnimation as |currentModal|}}
     {{#if currentModal}}
-      <div class="modal-background"></div>
-      <div class="modal-container" onclick={{action (ignore-children currentModal.onOutsideClick) }}>
+      <div class="modal-container">
+        <div class="modal-background" onclick={{action currentModal.onOutsideClick}}></div>
         <div class="modal-dialog" >
           {{component currentModal.body}}
         </div>


### PR DESCRIPTION
I believe this eliminates the need to use ignore-children which I missed because it wasn't in the example.  