### PR TITLE
fastboot compat

### DIFF
--- a/addon/components/from-elsewhere.js
+++ b/addon/components/from-elsewhere.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
     return Ember.getOwner(this).lookup('service:fastboot');
   }),
   isFastBoot: Ember.computed('fastboot', function() {
-    return this.get('fastboot') && this.get('fastboot.isFastBoot');
+    return this.get('fastboot.isFastBoot');
   }),
 
   // We don't yield any content on the very first render pass, because

--- a/addon/components/from-elsewhere.js
+++ b/addon/components/from-elsewhere.js
@@ -12,12 +12,19 @@ export default Ember.Component.extend({
     }
   },
 
+  fastboot: Ember.computed(function() {
+    return Ember.getOwner(this).lookup('service:fastboot');
+  }),
+  isFastBoot: Ember.computed('fastboot', function() {
+    return this.get('fastboot') && this.get('fastboot.isFastBoot');
+  }),
+
   // We don't yield any content on the very first render pass, because
   // we want to give any concurrent {{to-elsewhere}} components a chance
   // to declare their intentions first. This allows the components
   // inside us to see a meaningful initial value on their initial
   // render.
-  initialized: false,
+  initialized: Ember.computed.bool('isFastBoot'),
   didInsertElement() {
     this._super();
     Ember.run.schedule('afterRender', () => this.set('initialized', true));

--- a/addon/components/to-elsewhere.js
+++ b/addon/components/to-elsewhere.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   layout,
   service: Ember.inject.service('ember-elsewhere'),
   tagName: '',
-  willRender() {
+  didReceiveAttrs() {
     this.get('service').show(Ember.guidFor(this), this.get('named'), this.get('send'));
   },
   willDestroyElement() {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-deploy": "0.6.0",
     "ember-cli-deploy-build": "0.1.1",
     "ember-cli-deploy-git": "0.1.0",
+    "ember-cli-fastboot": "1.0.0-beta.14",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-jshint": "^2.0.1",


### PR DESCRIPTION
default `initialized: true` when in FastBoot mode. changed `willRender` to `didReceiveAttrs` to ensure the template is rendered when in FastBoot