### PR TITLE
patch(destroying): Add guard to _process before attempting sets

### DIFF
--- a/addon/services/ember-elsewhere.js
+++ b/addon/services/ember-elsewhere.js
@@ -28,6 +28,10 @@ export default Service.extend({
   },
 
   _process() {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
     let newActives = {};
     let alive = this._alive;
 


### PR DESCRIPTION
We were hitting an issue in our mocha acceptance tests when destroying the application - as the elsewhere service gets destroyed before  `_process` is scheduled to run.