### PR TITLE
feature - passing an `outsideParams` object/value in `to-elsewhere`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When you're using the block form of `from-elsewhere`, it's entirely up to you wh
 {{to-elsewhere named="modal"
                send=(component "warning-message")
                outsideParams=(hash onOutsideClick=(action "close") 
-                      heading="heading text")
+                              title="modal title")
                           }}
 ```
 
@@ -73,7 +73,8 @@ When you're using the block form of `from-elsewhere`, it's entirely up to you wh
     <div class="modal-container">
       <div class="modal-background" onclick={{action outsideParams.onOutsideClick}}></div>
       <div class="modal-dialog" >
-        {{component currentModal heading=outsideParams.heading}}
+        <div class="modal-title">{{outsideParams.title}}</div>
+        {{component currentModal}}
       </div>
     </div>
   {{/liquid-bind}}

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ When you're using the block form of `from-elsewhere`, it's entirely up to you wh
 ```
 
 If you plan to `send` a component, you should use Ember's [component helper](https://guides.emberjs.com/release/components/defining-a-component/#toc_dynamically-rendering-a-component).
-If you need to provide additional content, you can use the `params` attribute.
-This allows for tree-shaking in build pipelines like [Embroider](https://github.com/embroider-build/embroider).
+The component helper accepts the component name and other properties, such as `{{component "my-component-name" someValue="something"}}`, which will cover most use cases.
+However, if you need to provide additional content to use outside of the component scope, that is when you can use the `params` attribute.
 
 ## Crossing Engines
 

--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ When you're using the block form of `from-elsewhere`, it's entirely up to you wh
 ```hbs
 {{to-elsewhere named="modal"
                send=(component "warning-message")
-               params=(hash onOutsideClick=(action "close") 
+               outsideParams=(hash onOutsideClick=(action "close") 
                       heading="heading text")
                           }}
 ```
 
 ```hbs
-{{#from-elsewhere name="modal" as |modal params|}}
+{{#from-elsewhere name="modal" as |modal outsideParams|}}
   {{#liquid-bind modal as |currentModal|}}
     <div class="modal-container">
-      <div class="modal-background" onclick={{action params.onOutsideClick}}></div>
+      <div class="modal-background" onclick={{action outsideParams.onOutsideClick}}></div>
       <div class="modal-dialog" >
-        {{component currentModal heading=params.heading}}
+        {{component currentModal heading=outsideParams.heading}}
       </div>
     </div>
   {{/liquid-bind}}
@@ -82,7 +82,7 @@ When you're using the block form of `from-elsewhere`, it's entirely up to you wh
 
 If you plan to `send` a component, you should use Ember's [component helper](https://guides.emberjs.com/release/components/defining-a-component/#toc_dynamically-rendering-a-component).
 The component helper accepts the component name and other properties, such as `{{component "my-component-name" someValue="something"}}`, which will cover most use cases.
-However, if you need to provide additional content to use outside of the component scope, that is when you can use the `params` attribute.
+However, if you need to provide additional content to use outside of the component scope, that is when you can use the `outsideParams` attribute.
 
 ## Crossing Engines
 

--- a/README.md
+++ b/README.md
@@ -57,26 +57,32 @@ There might be use cases where you would like to render multiple component into 
 
 ## Passing additional state through to the target
 
-When you're using the block form of `from-elsewhere`, it's entirely up to you what value you send to the target. It can be more than just a component. Here is a complete example of an animatable modal that supports an `onOutsideClick` action while providing shared layout for the background and container:
+When you're using the block form of `from-elsewhere`, it's entirely up to you what information you pass to the target. It can be more than just a component. Here is a complete example of an animatable modal that supports an `onOutsideClick` action while providing shared layout for the background and container:
 
 ```hbs
 {{to-elsewhere named="modal"
-               send=(hash body=(component "warning-message")
-                          onOutsideClick=(action "close")) }}
+               send=(component "warning-message")
+               params=(hash onOutsideClick=(action "close") 
+                      heading="heading text")
+                          }}
 ```
 
 ```hbs
-{{#from-elsewhere name="modal" as |modal|}}
+{{#from-elsewhere name="modal" as |modal params|}}
   {{#liquid-bind modal as |currentModal|}}
     <div class="modal-container">
-      <div class="modal-background" onclick={{action currentModal.onOutsideClick}}></div>
+      <div class="modal-background" onclick={{action params.onOutsideClick}}></div>
       <div class="modal-dialog" >
-        {{component currentModal.body}}
+        {{component currentModal heading=params.heading}}
       </div>
     </div>
   {{/liquid-bind}}
 {{/from-elsewhere}}
 ```
+
+If you plan to `send` a component, you should use Ember's [component helper](https://guides.emberjs.com/release/components/defining-a-component/#toc_dynamically-rendering-a-component).
+If you need to provide additional content, you can use the `params` attribute.
+This allows for tree-shaking in build pipelines like [Embroider](https://github.com/embroider-build/embroider).
 
 ## Crossing Engines
 

--- a/addon/components/to-elsewhere.js
+++ b/addon/components/to-elsewhere.js
@@ -11,7 +11,7 @@ export default Component.extend({
     if (this.get('name')) {
       throw new Error(`to-elsewhere takes a "named=" parameter, not "name="`);
     }
-    this.get('service').show(guidFor(this), this.get('named'), this.get('send'), this.get('params'));
+    this.get('service').show(guidFor(this), this.get('named'), this.get('send'), this.get('outsideParams'));
   },
   willDestroyElement() {
     this.get('service').clear(guidFor(this));

--- a/addon/components/to-elsewhere.js
+++ b/addon/components/to-elsewhere.js
@@ -11,7 +11,7 @@ export default Component.extend({
     if (this.get('name')) {
       throw new Error(`to-elsewhere takes a "named=" parameter, not "name="`);
     }
-    this.get('service').show(guidFor(this), this.get('named'), this.get('send'));
+    this.get('service').show(guidFor(this), this.get('named'), this.get('send'), this.get('params'));
   },
   willDestroyElement() {
     this.get('service').clear(guidFor(this));

--- a/addon/services/ember-elsewhere.js
+++ b/addon/services/ember-elsewhere.js
@@ -11,11 +11,12 @@ export default Service.extend({
     this._counter = 1;
   },
 
-  show(sourceId, name, component) {
+  show(sourceId, name, component, params) {
     this._alive[sourceId] = {
       target: name || 'default',
       component,
-      order: this._counter++
+      order: this._counter++,
+      params
     };
     this._schedule();
   },
@@ -38,10 +39,9 @@ export default Service.extend({
     let alive = this._alive;
 
     Object.keys(alive).forEach((sourceId) => {
-      let { target, component, order } = alive[sourceId];
+      let { target, component, order, params } = alive[sourceId];
       newActives[target] = newActives[target] || emArray();
-      let newActive = component ? { component, order } : null;
-
+      let newActive = component ? { component, order, params } : null;
       newActives[target].push(newActive);
     });
     Object.keys(newActives).forEach((target) => {

--- a/addon/services/ember-elsewhere.js
+++ b/addon/services/ember-elsewhere.js
@@ -11,12 +11,12 @@ export default Service.extend({
     this._counter = 1;
   },
 
-  show(sourceId, name, component, params) {
+  show(sourceId, name, component, outsideParams) {
     this._alive[sourceId] = {
       target: name || 'default',
       component,
       order: this._counter++,
-      params
+      outsideParams
     };
     this._schedule();
   },
@@ -39,9 +39,9 @@ export default Service.extend({
     let alive = this._alive;
 
     Object.keys(alive).forEach((sourceId) => {
-      let { target, component, order, params } = alive[sourceId];
+      let { target, component, order, outsideParams } = alive[sourceId];
       newActives[target] = newActives[target] || emArray();
-      let newActive = component ? { component, order, params } : null;
+      let newActive = component ? { component, order, outsideParams } : null;
       newActives[target].push(newActive);
     });
     Object.keys(newActives).forEach((target) => {

--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -1,9 +1,9 @@
 {{#if initialized}}
   {{#if hasBlock}}
-    {{yield (get (get service.actives name) 'lastObject.component') (get (get service.actives name) 'lastObject.params')}}
+    {{yield (get (get service.actives name) 'lastObject.component') (get (get service.actives name) 'lastObject.outsideParams')}}
   {{else}}
     {{#with (get (get service.actives name) 'lastObject.component') as |c|}}
-      {{component c params=(get (get service.actives name) 'lastObject.params')}}
+      {{component c outsideParams=(get (get service.actives name) 'lastObject.outsideParams')}}
     {{/with}}
   {{/if}}
 {{/if}}

--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -1,6 +1,6 @@
 {{#if initialized}}
   {{#if hasBlock}}
-    {{yield (get (get service.actives name) 'lastObject.component') }}
+    {{yield (get (get service.actives name) 'lastObject.component') (get (get service.actives name) 'lastObject.params')}}
   {{else}}
     {{#with (get (get service.actives name) 'lastObject.component') as |c|}}
       {{component c params=(get (get service.actives name) 'lastObject.params')}}

--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -4,7 +4,7 @@
       {{yield active.lastObject.component active.lastObject.outsideParams}}
     {{else}}
       {{#with active.lastObject.component as |c|}}
-        {{component c outsideParams=active.lastObject.outsideParams}}
+        {{component c}}
       {{/with}}
     {{/if}}
   {{/let}}

--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -3,7 +3,7 @@
     {{yield (get (get service.actives name) 'lastObject.component') }}
   {{else}}
     {{#with (get (get service.actives name) 'lastObject.component') as |c|}}
-      {{component c}}
+      {{component c params=(get (get service.actives name) 'lastObject.params')}}
     {{/with}}
   {{/if}}
 {{/if}}

--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -1,9 +1,11 @@
 {{#if initialized}}
-  {{#if hasBlock}}
-    {{yield (get (get service.actives name) 'lastObject.component') (get (get service.actives name) 'lastObject.outsideParams')}}
-  {{else}}
-    {{#with (get (get service.actives name) 'lastObject.component') as |c|}}
-      {{component c outsideParams=(get (get service.actives name) 'lastObject.outsideParams')}}
-    {{/with}}
-  {{/if}}
+  {{#let (get service.actives name) as |active| }}
+    {{#if hasBlock}}
+      {{yield active.lastObject.component active.lastObject.outsideParams}}
+    {{else}}
+      {{#with active.lastObject.component as |c|}}
+        {{component c outsideParams=active.lastObject.outsideParams}}
+      {{/with}}
+    {{/if}}
+  {{/let}}
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.16.0",
-    "ember-cli-htmlbars": "^3.0.0"
+    "ember-cli-htmlbars": "^3.0.0",
+    "ember-let-polyfill": "^0.1.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -56,8 +56,12 @@ module('Integration | Component | to elsewhere', function(hooks) {
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Foo');
   });
 
-  test('it accepts a params object', async function(assert) {
+  test('it accepts a params object for inline form', async function(assert) {
     await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
+    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
+  });
+  test('it accepts a params object for block form', async function(assert) {
+    await render(hbs`<div class="source">{{#to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}Some content{{/to-elsewhere}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
   });
 

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -9,6 +9,7 @@ module('Integration | Component | to elsewhere', function(hooks) {
   hooks.beforeEach(function() {
     this.owner.register('template:components/x-foo', hbs`Hello World from Foo`);
     this.owner.register('template:components/x-bar', hbs`Hello World from Bar`);
+    this.owner.register('template:components/x-baz', hbs`{{params.greeting}} from Baz`);
   });
 
   test('it works with inline from-elsewhere', async function(assert) {
@@ -53,6 +54,11 @@ module('Integration | Component | to elsewhere', function(hooks) {
   test('source can come before destination', async function(assert) {
     await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-foo")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Foo');
+  });
+
+  test('it accepts a params object', async function(assert) {
+    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
+    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
   });
 
 });

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -57,10 +57,6 @@ module('Integration | Component | to elsewhere', function(hooks) {
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Foo');
   });
 
-  test('it accepts an outsideParams object for inline form', async function(assert) {
-    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-baz") outsideParams=(hash greeting="Hello World")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
-    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
-  });
   test('it accepts an outsideParams object for block form', async function(assert) {
     await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-blip") outsideParams=(hash greeting="Hello World")}}</div><div class="my-target">{{#from-elsewhere name="my-target" as |content outsideParams|}} {{component content outsideParams=outsideParams}}{{/from-elsewhere}}</div>`);
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Blip');

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -9,8 +9,8 @@ module('Integration | Component | to elsewhere', function(hooks) {
   hooks.beforeEach(function() {
     this.owner.register('template:components/x-foo', hbs`Hello World from Foo`);
     this.owner.register('template:components/x-bar', hbs`Hello World from Bar`);
-    this.owner.register('template:components/x-baz', hbs`{{params.greeting}} from Baz`);
-    this.owner.register('template:components/x-blip', hbs`{{params.greeting}} from Blip`);    
+    this.owner.register('template:components/x-baz', hbs`{{outsideParams.greeting}} from Baz`);
+    this.owner.register('template:components/x-blip', hbs`{{outsideParams.greeting}} from Blip`);    
   });
 
   test('it works with inline from-elsewhere', async function(assert) {
@@ -57,12 +57,12 @@ module('Integration | Component | to elsewhere', function(hooks) {
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Foo');
   });
 
-  test('it accepts a params object for inline form', async function(assert) {
-    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
+  test('it accepts an outsideParams object for inline form', async function(assert) {
+    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-baz") outsideParams=(hash greeting="Hello World")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
   });
-  test('it accepts a params object for block form', async function(assert) {
-    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-blip") params=(hash greeting="Hello World")}}</div><div class="my-target">{{#from-elsewhere name="my-target" as |content params|}} {{component content params=params}}{{/from-elsewhere}}</div>`);
+  test('it accepts an outsideParams object for block form', async function(assert) {
+    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-blip") outsideParams=(hash greeting="Hello World")}}</div><div class="my-target">{{#from-elsewhere name="my-target" as |content outsideParams|}} {{component content outsideParams=outsideParams}}{{/from-elsewhere}}</div>`);
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Blip');
   });
 

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -10,6 +10,7 @@ module('Integration | Component | to elsewhere', function(hooks) {
     this.owner.register('template:components/x-foo', hbs`Hello World from Foo`);
     this.owner.register('template:components/x-bar', hbs`Hello World from Bar`);
     this.owner.register('template:components/x-baz', hbs`{{params.greeting}} from Baz`);
+    this.owner.register('template:components/x-blip', hbs`{{params.greeting}} from Blip`);    
   });
 
   test('it works with inline from-elsewhere', async function(assert) {
@@ -61,8 +62,8 @@ module('Integration | Component | to elsewhere', function(hooks) {
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
   });
   test('it accepts a params object for block form', async function(assert) {
-    await render(hbs`<div class="source">{{#to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}Some content{{/to-elsewhere}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
-    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
+    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-blip") params=(hash greeting="Hello World")}}</div><div class="my-target">{{#from-elsewhere name="my-target" as |content params|}} {{component content params=params}}{{/from-elsewhere}}</div>`);
+    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Blip');
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,6 +2454,14 @@ ember-hash-helper-polyfill@^0.2.0:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^2.1.0"
 
+ember-let-polyfill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-let-polyfill/-/ember-let-polyfill-0.1.0.tgz#9d37c610441eb41eaaea3a6782bbd4203f5cf0a9"
+  integrity sha512-olLHpS7JnqZcfyYRXcdLATYwDIopKA+ZzI8xswzCIcBYoRgoUJY7E/eW84Unu8ea1jtr/Unx+dQrsU+NrNSoBg==
+  dependencies:
+    ember-cli-babel "^6.16.0"
+    ember-cli-version-checker "^2.1.2"
+
 ember-load-initializers@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.1.0.tgz#4edacc0f3a14d9f53d241ac3e5561804c8377978"


### PR DESCRIPTION
Partially addresses #31 

This does not include the deprecation of `send`ing components in a hash.