### PR TITLE
WIP Deprecate sending a component in a `send` hash

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,58 @@
+# Deprecations
+
+Follow this guide to resolve any deprecations you may see in your app.
+If your project does not directly depend on `ember-elsewhere` and you
+see a deprecation warning, look at your `npm-lockfile` or `yarn.lock` to see
+which of your dependencies may be using ember-elsewhere, and
+file an issue for that addon.
+
+## send-component-hash
+
+_removed in version 2.0.0_
+
+If you need to `send` a component, you should not put it inside a hash helper.
+Hashes of non-component content may be passed to `params` instead.
+
+For example, this is deprecated:
+
+```hbs
+{{!-- curly component invocation example --}}
+{{to-elsewhere named="my-target"
+    send=(hash myComponent=(component "my-component")) foo="foo" bar="bar"}}
+
+{{!-- angle bracket component invocation example --}}
+<ToElsewhere @named="my-target" 
+    send={{hash @myComponent=(component "my-component")) @foo="foo" @bar="bar"}}
+/>
+```
+
+To resolve this deprecation, `send` only the component and put the rest of the
+content into `params`:
+
+```hbs
+{{to-elsewhere named="my-target"
+    send=(component "my-component") 
+    params=(hash foo="foo" bar="bar"}}
+
+<ToElsewhere @named="my-target"
+    @send={{component "my-component"}}
+    @params={{hash foo="foo" bar="bar"}}
+/>
+```
+
+The params attribute can now be used in the `from-elsewhere` block like this:
+
+```hbs
+{{#from-elsewhere name="my-target" as |content params|}}
+    {{params.foo}} 
+    {{component content baz=params.bar}} 
+{{/from-elsewhere}}
+
+<FromElsewhere @name="my-target" as |content params|}}
+    {{params.foo}} 
+    {{component content baz=params.bar}} 
+{{/FromElsewhere}}
+```
+
+The old behavior was deprecated because it is incompatible with tree-shaking
+features of build systems like [Embroider](https://github.com/embroider-build/embroider).

--- a/README.md
+++ b/README.md
@@ -57,26 +57,32 @@ There might be use cases where you would like to render multiple component into 
 
 ## Passing additional state through to the target
 
-When you're using the block form of `from-elsewhere`, it's entirely up to you what value you send to the target. It can be more than just a component. Here is a complete example of an animatable modal that supports an `onOutsideClick` action while providing shared layout for the background and container:
+When you're using the block form of `from-elsewhere`, it's entirely up to you what information you pass to the target. It can be more than just a component. Here is a complete example of an animatable modal that supports an `onOutsideClick` action while providing shared layout for the background and container:
 
 ```hbs
 {{to-elsewhere named="modal"
-               send=(hash body=(component "warning-message")
-                          onOutsideClick=(action "close")) }}
+               send=(component "warning-message")
+               params=(hash onOutsideClick=(action "close") 
+                      heading="heading text")
+                          }}
 ```
 
 ```hbs
-{{#from-elsewhere name="modal" as |modal|}}
+{{#from-elsewhere name="modal" as |modal params|}}
   {{#liquid-bind modal as |currentModal|}}
     <div class="modal-container">
-      <div class="modal-background" onclick={{action currentModal.onOutsideClick}}></div>
+      <div class="modal-background" onclick={{action params.onOutsideClick}}></div>
       <div class="modal-dialog" >
-        {{component currentModal.body}}
+        {{component currentModal heading=params.heading}}
       </div>
     </div>
   {{/liquid-bind}}
 {{/from-elsewhere}}
 ```
+
+If you plan to `send` a component, you should use Ember's [component helper](https://guides.emberjs.com/release/components/defining-a-component/#toc_dynamically-rendering-a-component).
+If you need to provide additional content, you can use the `params` attribute.
+This allows for tree-shaking in build pipelines like [Embroider](https://github.com/embroider-build/embroider).
 
 ## Crossing Engines
 

--- a/addon/components/to-elsewhere.js
+++ b/addon/components/to-elsewhere.js
@@ -2,6 +2,7 @@ import { guidFor } from '@ember/object/internals';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import layout from '../templates/components/to-elsewhere';
+import { deprecate } from '@ember/application/deprecations';
 
 export default Component.extend({
   layout,
@@ -21,13 +22,19 @@ export default Component.extend({
     // typeof null is object, so we need to check for it explicitly
     if (this.send && typeof this.send === 'object' ) {
       for (let key in this.send) {
-        const isAComponent = this.send[key].inner && this.send[key].inner.hasOwnProperty('ComponentClass')
+        const isAComponent = this.send[key].inner && this.send[key].inner.hasOwnProperty('ComponentClass');
         if (isAComponent) {
           // show deprecation warning if someone does `send=(hash a=(component "my-component"))`
-          console.warn('DEPRECATION in ember-elsewhere: Sending a component inside a hash is deprecated. Use params instead to provide a hash of content. For example, `send=(component "my-component") params=(hash foo="foo" bar="bar")`')
+          deprecate(`Sending a component inside a hash is deprecated in the ember-elsewhere addon. Use params instead to provide a hash of content. For example, send=(component "my-component") params=(hash foo="foo" bar="bar")`, 
+            false,
+            {
+              id: 'send-component-hash',
+              until: '2.0.0',
+              url: 'https://github.com/ef4/ember-elsewhere/blob/master/DEPRECATIONS.md'
+            }
+          );
         }
       }
     }
   }
-
 });

--- a/addon/components/to-elsewhere.js
+++ b/addon/components/to-elsewhere.js
@@ -11,10 +11,23 @@ export default Component.extend({
     if (this.get('name')) {
       throw new Error(`to-elsewhere takes a "named=" parameter, not "name="`);
     }
+    this.checkForDeprecations();
     this.get('service').show(guidFor(this), this.get('named'), this.get('send'), this.get('params'));
   },
   willDestroyElement() {
     this.get('service').clear(guidFor(this));
+  },
+  checkForDeprecations() {
+    // typeof null is object, so we need to check for it explicitly
+    if (this.send && typeof this.send === 'object' ) {
+      for (let key in this.send) {
+        const isAComponent = this.send[key].inner && this.send[key].inner.hasOwnProperty('ComponentClass')
+        if (isAComponent) {
+          // show deprecation warning if someone does `send=(hash a=(component "my-component"))`
+          console.warn('DEPRECATION in ember-elsewhere: Sending a component inside a hash is deprecated. Use params instead to provide a hash of content. For example, `send=(component "my-component") params=(hash foo="foo" bar="bar")`')
+        }
+      }
+    }
   }
 
 });

--- a/addon/components/to-elsewhere.js
+++ b/addon/components/to-elsewhere.js
@@ -11,7 +11,7 @@ export default Component.extend({
     if (this.get('name')) {
       throw new Error(`to-elsewhere takes a "named=" parameter, not "name="`);
     }
-    this.get('service').show(guidFor(this), this.get('named'), this.get('send'));
+    this.get('service').show(guidFor(this), this.get('named'), this.get('send'), this.get('params'));
   },
   willDestroyElement() {
     this.get('service').clear(guidFor(this));

--- a/addon/services/ember-elsewhere.js
+++ b/addon/services/ember-elsewhere.js
@@ -11,11 +11,12 @@ export default Service.extend({
     this._counter = 1;
   },
 
-  show(sourceId, name, component) {
+  show(sourceId, name, component, params) {
     this._alive[sourceId] = {
       target: name || 'default',
       component,
-      order: this._counter++
+      order: this._counter++,
+      params
     };
     this._schedule();
   },
@@ -38,10 +39,9 @@ export default Service.extend({
     let alive = this._alive;
 
     Object.keys(alive).forEach((sourceId) => {
-      let { target, component, order } = alive[sourceId];
+      let { target, component, order, params } = alive[sourceId];
       newActives[target] = newActives[target] || emArray();
-      let newActive = component ? { component, order } : null;
-
+      let newActive = component ? { component, order, params } : null;
       newActives[target].push(newActive);
     });
     Object.keys(newActives).forEach((target) => {

--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -1,6 +1,6 @@
 {{#if initialized}}
   {{#if hasBlock}}
-    {{yield (get (get service.actives name) 'lastObject.component') }}
+    {{yield (get (get service.actives name) 'lastObject.component') (get (get service.actives name) 'lastObject.params')}}
   {{else}}
     {{#with (get (get service.actives name) 'lastObject.component') as |c|}}
       {{component c params=(get (get service.actives name) 'lastObject.params')}}

--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -3,7 +3,7 @@
     {{yield (get (get service.actives name) 'lastObject.component') }}
   {{else}}
     {{#with (get (get service.actives name) 'lastObject.component') as |c|}}
-      {{component c}}
+      {{component c params=(get (get service.actives name) 'lastObject.params')}}
     {{/with}}
   {{/if}}
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.3.0",
     "ember-source-channel-url": "^1.0.1",

--- a/tests/integration/components/deprecations-test.js
+++ b/tests/integration/components/deprecations-test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+// import helper from 'ember-qunit-assert-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -19,18 +20,6 @@ module('Integration | Component | deprecations', function(hooks) {
       </div>
       <div class="source">{{to-elsewhere named="my-target" send=(hash myComponent=(component "x-foo") someText="some text")}}</div>
       `);
-      assert.ok(false); // todo look up the deprecation
-  });
-
-  test('shows a deprecation if a hash includes a component string', async function(assert) {
-    await render(hbs`
-      <div class="my-target">
-        {{#from-elsewhere name="my-target" as |content|}}
-          {{component content.myComponent}}
-        {{/from-elsewhere}}
-      </div>
-      <div class="source">{{to-elsewhere named="my-target" send=(hash myComponent="x-foo" someText="some text")}}</div>
-      `);
-    assert.ok(false); // todo look up the deprecation
+    assert.expectDeprecation(/Sending a component inside a hash/);
   });
 });

--- a/tests/integration/components/deprecations-test.js
+++ b/tests/integration/components/deprecations-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | deprecations', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register('template:components/x-foo', hbs`Hello World from Foo`);
+  });
+
+  test('shows a deprecation if a hash includes a component', async function(assert) {
+    await render(hbs`
+      <div class="my-target">
+        {{#from-elsewhere name="my-target" as |content|}}
+          {{content.myComponent}}
+        {{/from-elsewhere}}
+      </div>
+      <div class="source">{{to-elsewhere named="my-target" send=(hash myComponent=(component "x-foo") someText="some text")}}</div>
+      `);
+      assert.ok(false); // todo look up the deprecation
+  });
+
+  test('shows a deprecation if a hash includes a component string', async function(assert) {
+    await render(hbs`
+      <div class="my-target">
+        {{#from-elsewhere name="my-target" as |content|}}
+          {{component content.myComponent}}
+        {{/from-elsewhere}}
+      </div>
+      <div class="source">{{to-elsewhere named="my-target" send=(hash myComponent="x-foo" someText="some text")}}</div>
+      `);
+    assert.ok(false); // todo look up the deprecation
+  });
+});

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -56,8 +56,12 @@ module('Integration | Component | to elsewhere', function(hooks) {
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Foo');
   });
 
-  test('it accepts a params object', async function(assert) {
+  test('it accepts a params object for inline form', async function(assert) {
     await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
+    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
+  });
+  test('it accepts a params object for block form', async function(assert) {
+    await render(hbs`<div class="source">{{#to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}Some content{{/to-elsewhere}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
   });
 

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -9,6 +9,7 @@ module('Integration | Component | to elsewhere', function(hooks) {
   hooks.beforeEach(function() {
     this.owner.register('template:components/x-foo', hbs`Hello World from Foo`);
     this.owner.register('template:components/x-bar', hbs`Hello World from Bar`);
+    this.owner.register('template:components/x-baz', hbs`{{params.greeting}} from Baz`);
   });
 
   test('it works with inline from-elsewhere', async function(assert) {
@@ -53,6 +54,11 @@ module('Integration | Component | to elsewhere', function(hooks) {
   test('source can come before destination', async function(assert) {
     await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-foo")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Foo');
+  });
+
+  test('it accepts a params object', async function(assert) {
+    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
+    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
   });
 
 });

--- a/tests/integration/components/to-elsewhere-test.js
+++ b/tests/integration/components/to-elsewhere-test.js
@@ -10,6 +10,7 @@ module('Integration | Component | to elsewhere', function(hooks) {
     this.owner.register('template:components/x-foo', hbs`Hello World from Foo`);
     this.owner.register('template:components/x-bar', hbs`Hello World from Bar`);
     this.owner.register('template:components/x-baz', hbs`{{params.greeting}} from Baz`);
+    this.owner.register('template:components/x-blip', hbs`{{params.greeting}} from Blip`);    
   });
 
   test('it works with inline from-elsewhere', async function(assert) {
@@ -61,8 +62,8 @@ module('Integration | Component | to elsewhere', function(hooks) {
     assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
   });
   test('it accepts a params object for block form', async function(assert) {
-    await render(hbs`<div class="source">{{#to-elsewhere named="my-target" send=(component "x-baz") params=(hash greeting="Hello World")}}Some content{{/to-elsewhere}}</div><div class="my-target">{{from-elsewhere name="my-target"}}</div>`);
-    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Baz');
+    await render(hbs`<div class="source">{{to-elsewhere named="my-target" send=(component "x-blip") params=(hash greeting="Hello World")}}</div><div class="my-target">{{#from-elsewhere name="my-target" as |content params|}} {{component content params=params}}{{/from-elsewhere}}</div>`);
+    assert.dom(this.element.querySelector('.my-target')).hasText('Hello World from Blip');
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,6 +493,13 @@ babel-plugin-ember-modules-api-polyfill@^2.3.2:
   dependencies:
     ember-rfc176-data "^0.3.0"
 
+babel-plugin-ember-modules-api-polyfill@^2.6.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
+  integrity sha512-c03h50291phJ2gQxo/aIOvFQE2c6glql1A7uagE3XbPXpKVAJOUxtVDjvWG6UAB6BC5ynsJfMWvY0w4TPRKIHQ==
+  dependencies:
+    ember-rfc176-data "^0.3.9"
+
 babel-plugin-htmlbars-inline-precompile@^0.2.5:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.6.tgz#c00b8a3f4b32ca04bf0f0d5169fcef3b5a66d69d"
@@ -992,6 +999,22 @@ broccoli-babel-transpiler@^6.0.0, broccoli-babel-transpiler@^6.4.5:
     rsvp "^4.8.2"
     workerpool "^2.3.0"
 
+broccoli-babel-transpiler@^6.5.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz#a4afc8d3b59b441518eb9a07bd44149476e30738"
+  integrity sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==
+  dependencies:
+    babel-core "^6.26.0"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-persistent-filter "^1.4.3"
+    clone "^2.0.0"
+    hash-for-dep "^1.2.3"
+    heimdalljs-logger "^0.1.7"
+    json-stable-stringify "^1.0.0"
+    rsvp "^4.8.2"
+    workerpool "^2.3.0"
+
 broccoli-builder@^0.18.8:
   version "0.18.14"
   resolved "https://registry.yarnpkg.com/broccoli-builder/-/broccoli-builder-0.18.14.tgz#4b79e2f844de11a4e1b816c3f49c6df4776c312d"
@@ -1085,7 +1108,7 @@ broccoli-file-creator@^1.1.1:
     broccoli-plugin "^1.1.0"
     mkdirp "^0.5.1"
 
-broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
+broccoli-filter@^1.0.1, broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"
   dependencies:
@@ -2098,6 +2121,25 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
+ember-cli-babel@^6.9.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
+
 ember-cli-broccoli-sane-watcher@^2.0.4:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-2.1.1.tgz#1687adada9022de26053fba833dc7dd10f03dd08"
@@ -2469,6 +2511,14 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-qunit-assert-helpers@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-qunit-assert-helpers/-/ember-qunit-assert-helpers-0.2.2.tgz#6fec8a33fd0d2c3fb6202f849291a309581727a4"
+  integrity sha512-P5eAqD753+p/qEeBi6OGpl2EzRxx8O9dUnr6HgyxU9fqQsSNQkJNGZ+ajbtePI8oMDGm+X7uOnf1+BgQ7eJ7qg==
+  dependencies:
+    broccoli-filter "^1.0.1"
+    ember-cli-babel "^6.9.0"
+
 ember-qunit@^3.3.2:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.4.1.tgz#204a2d39a5d44d494c56bf17cf3fd12f06210359"
@@ -2496,6 +2546,11 @@ ember-resolver@^5.0.1:
 ember-rfc176-data@^0.3.0, ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.3.tgz#27fba08d540a7463a4366c48eaa19c5a44971a39"
+
+ember-rfc176-data@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.9.tgz#44b6e051ead6c044ea87bd551f402e2cf89a7e3d"
+  integrity sha512-EiTo5YQS0Duy0xp9gCP8ekzv9vxirNi7MnIB4zWs+thtWp/mEKgf5mkiiLU2+oo8C5DuavVHhoPQDmyxh8Io1Q==
 
 ember-router-generator@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
If someone does this, it will issue a deprecation warning:

```hbs
{{to-elsewhere named="my-target" 
    send=(hash myComponent=(component "x-foo") 
                    someText="some text"
    )
}}
```

Marked WIP because it builds on #32, and I expect to make some changes based on the review of that PR.

The main files to look at are `deprecations-test.js` and `to-elsewhere.js`