### PR TITLE
Feature - allow to customize ordering of components when `multiple-from-elsewhere` is used

### DIFF
--- a/addon/components/to-elsewhere.js
+++ b/addon/components/to-elsewhere.js
@@ -11,7 +11,7 @@ export default Component.extend({
     if (this.get('name')) {
       throw new Error(`to-elsewhere takes a "named=" parameter, not "name="`);
     }
-    this.get('service').show(guidFor(this), this.get('named'), this.get('send'), this.get('outsideParams'));
+    this.get('service').show(guidFor(this), this.get('named'), this.get('send'), this.get('outsideParams'), this.get('order'));
   },
   willDestroyElement() {
     this.get('service').clear(guidFor(this));

--- a/addon/services/ember-elsewhere.js
+++ b/addon/services/ember-elsewhere.js
@@ -11,11 +11,17 @@ export default Service.extend({
     this._counter = 1;
   },
 
-  show(sourceId, name, component, outsideParams) {
+  show(sourceId, name, component, outsideParams, order = 0) {
+    // if current component has specific order that is greater than current internal count
+    // update internal count so any subsequent component that does not provide order will
+    // be after.
+    if (this._counter < order) {
+      this._counter = order + 1
+    }
     this._alive[sourceId] = {
       target: name || 'default',
       component,
-      order: this._counter++,
+      order: order || this._counter++,
       outsideParams
     };
     this._schedule();


### PR DESCRIPTION
Provide a way to customize ordering of components when `multiple-form-elsewhere` is used.

```hbs
{{multiple-from-elsewhere name="actions"}}
...
{{#if foo}}
  {{to-elsewhere named="actions" send=(component "test-button" text="Button1") order=1}}
{{/if}}
{{#if bar}}
  {{to-elsewhere named="actions" send=(component "test-button" text="Button2") order=2}}
{{/if}}
{{#if flip}}
  {{to-elsewhere named="actions" send=(component "test-button" text="Button3") order=3}}
{{/if}}
```
Regardless of which component gets rendered first, it will always honour the specified order.  
```
Button1
Button2
Button3
```