### PR TITLE
Address hasBlock deprecation: update to has-block

### DIFF
--- a/addon/templates/components/from-elsewhere.hbs
+++ b/addon/templates/components/from-elsewhere.hbs
@@ -1,6 +1,6 @@
 {{#if initialized}}
   {{#let (get service.actives name) as |active| }}
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       {{yield active.lastObject.component active.lastObject.outsideParams}}
     {{else}}
       {{#with active.lastObject.component as |c|}}

--- a/addon/templates/components/multiple-from-elsewhere.hbs
+++ b/addon/templates/components/multiple-from-elsewhere.hbs
@@ -1,6 +1,6 @@
 {{#if initialized}}
   {{#each (get service.actives name) as |source|}}
-    {{#if hasBlock}}
+    {{#if (has-block)}}
       {{yield source.component source.outsideParams}}
     {{else}}
       {{component source.component}}


### PR DESCRIPTION
As of Ember 3.26,`hasBlock` has been deprecated in favor of `(has-block)`. This updates the addon's two uses of `hasBlock` accordingly.

RFC: https://github.com/emberjs/rfcs/pull/689
PR: https://github.com/emberjs/ember.js/pull/19374
Deprecation Guide: https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params